### PR TITLE
fix(mcp-docs): add GradientWorks__ prefix and rename label to actionName

### DIFF
--- a/src/GWMCPDocsProcessor.ts
+++ b/src/GWMCPDocsProcessor.ts
@@ -170,7 +170,7 @@ function renderPropertyTable(
 function renderAction(classModel: ClassModel, actionName: string, typeRegistry: Map<string, ClassModel>): string {
   const lines: string[] = [`## ${actionName}`, ''];
 
-  lines.push(`**Action class:** \`GradientWorks__${classModel.getClassName()}\``, '');
+  lines.push(`**\`actionName\`:** \`GradientWorks__${classModel.getClassName()}\``, '');
 
   const fullDesc = classModel.getDescription().trim();
   // Strip any @preamble / @end-preamble block — that content is hoisted to the category header.

--- a/src/GWMCPDocsProcessor.ts
+++ b/src/GWMCPDocsProcessor.ts
@@ -170,7 +170,7 @@ function renderPropertyTable(
 function renderAction(classModel: ClassModel, actionName: string, typeRegistry: Map<string, ClassModel>): string {
   const lines: string[] = [`## ${actionName}`, ''];
 
-  lines.push(`**Action class:** \`${classModel.getClassName()}\``, '');
+  lines.push(`**Action class:** \`GradientWorks__${classModel.getClassName()}\``, '');
 
   const fullDesc = classModel.getDescription().trim();
   // Strip any @preamble / @end-preamble block — that content is hoisted to the category header.


### PR DESCRIPTION
## Summary
- The `GWMCPDocsProcessor` was emitting bare class names (e.g. `GWFXExecuteSubflowAction`) without the `GradientWorks__` managed package namespace prefix — flow configurations built from these docs would reference non-existent class names
- The label `**Action class:**` was renamed to `**\`actionName\`:**` so it matches the exact flow metadata property name, removing the indirection between the docs and what to write when building a flow

Both changes are in `renderAction()` in `GWMCPDocsProcessor.ts`.

## Test plan
- [ ] Run `make mcp-docs` against the Salesforce repo and verify all action entries show **\`actionName\`:** \`GradientWorks__<ClassName>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)